### PR TITLE
Fixed reference to 24LC256-Wiring.jpg

### DIFF
--- a/docs/eeprom.md
+++ b/docs/eeprom.md
@@ -44,4 +44,4 @@ void onStoreUpdate(void (*fptr)());
 
 
 ### 24LC256 Wiring
-![24LC256 Wiring](../images/24LC256-Wiring)
+![24LC256 Wiring](../images/24LC256-Wiring.jpg)


### PR DESCRIPTION
The current image wasn't shown in docs because of invalid reference.